### PR TITLE
Fix argument error when making broadcasts

### DIFF
--- a/app/jobs/broadcast_chirp_job.rb
+++ b/app/jobs/broadcast_chirp_job.rb
@@ -2,13 +2,14 @@ class BroadcastChirpJob < ApplicationJob
   queue_as :default
 
   def perform(chirp)
-    html_fragment = ChirpsController.render(partial: "chirps/chirp", locals: { chirp: chirp })
+    chirp_html_fragment = ChirpsController.render(partial: "chirps/chirp", locals: { chirp: chirp })
+    chirp_message = { chirp: chirp_html_fragment }
 
-    ActionCable.server.broadcast "firehose", chirp: html_fragment
-    ChirpsChannel.broadcast_to chirp.author, chirp: html_fragment
+    ActionCable.server.broadcast "firehose", chirp_message
+    ChirpsChannel.broadcast_to chirp.author, chirp_message
 
     chirp.interested_users.each do |follower|
-      TimelinesChannel.broadcast_to follower, chirp: html_fragment
+      TimelinesChannel.broadcast_to follower, chirp_message
     end
   end
 end


### PR DESCRIPTION
This broke with the upgrade to Ruby 3, which has stricter handling of keyword arguments (the Rails API here expects a real hash, not keyword args).